### PR TITLE
More monitorbench contributions

### DIFF
--- a/monitorbench.py
+++ b/monitorbench.py
@@ -153,7 +153,7 @@ class MonitorBench(FlowSpec):
         Increase CPU utilization in steps of 10%, ending at 100% utilization
         """
         for i in range(10):
-            spin_cpu_percentage(self.spin_secs/10, i*10)
+            spin_cpu_percentage(int(self.spin_secs/10), i*10)
         self.next(self.cpu_join)
 
     @step

--- a/monitorbench.py
+++ b/monitorbench.py
@@ -57,7 +57,7 @@ def _print_mem():
 @pypi_base(python="3.11.0", packages={"psutil": "5.9.7"})
 class MonitorBench(FlowSpec):
     spin_secs = Parameter(
-        "step_time", help="Run each step for this many seconds", default=300
+        "step_time", help="Run each step for this many seconds", default=600
     )
 
     @step

--- a/monitorbench.py
+++ b/monitorbench.py
@@ -319,7 +319,7 @@ class MonitorBench(FlowSpec):
             num_gigs = 8
             with NamedTemporaryFile() as tmp:
                 _make_file(tmp.name, num_gigs * 1000)
-            spin_cpu_percentage(self.spin_secs / 10)
+            spin_cpu_percentage(int(self.spin_secs / 10))
         self.next(self.io_join)
 
     @step

--- a/monitorbench.py
+++ b/monitorbench.py
@@ -153,7 +153,7 @@ class MonitorBench(FlowSpec):
         Increase CPU utilization in steps of 10%, ending at 100% utilization
         """
         for i in range(10):
-            self.spin_cpu_percentage(self.spin_secs/10, i*10)
+            spin_cpu_percentage(self.spin_secs/10, i*10)
         self.next(self.cpu_join)
 
     @step

--- a/monitorbench.py
+++ b/monitorbench.py
@@ -27,10 +27,11 @@ def spin_cpu(secs, half_load=False):
             time.sleep(0.0000002)
 
 def spin_cpu_percentage(seconds, percentage=100):
+    print(f"Running at {percentage}% CPU Utilization for {seconds} seconds...")
     for i in range(0, seconds):
         start_time = time.time()
         if i % 10 == 0:
-            print(f"Beginning work cycle {i}/{seconds}")
+            print(f"Beginning work cycle {i}/{seconds} seconds...")
         # Perform work for the required percentage of this second
         while (time.time() - start_time) < (percentage / 100.0):
             a = math.sqrt(64 * 64 * 64 * 64 * 64)

--- a/monitorbench.py
+++ b/monitorbench.py
@@ -18,14 +18,6 @@ def load_libc():
     return libc
 
 
-def spin_cpu(secs, half_load=False):
-    nu = time.time()
-    x = 0
-    while time.time() - nu < secs:
-        x += 1
-        if half_load:
-            time.sleep(0.0000002)
-
 def spin_cpu_percentage(seconds, percentage=100):
     print(f"Running at {percentage}% CPU Utilization for {seconds} seconds...")
     for i in range(0, seconds):
@@ -81,7 +73,7 @@ class MonitorBench(FlowSpec):
         """
         One core, 100% utilized
         """
-        spin_cpu(self.spin_secs, half_load=False)
+        spin_cpu_percentage(self.spin_secs)
         self.next(self.cpu_join)
 
     @resources(cpu=2)
@@ -90,7 +82,7 @@ class MonitorBench(FlowSpec):
         """
         Two cores, each 100% utilized
         """
-        parallel_map(lambda _: spin_cpu(self.spin_secs), [None] * 2)
+        parallel_map(lambda _: spin_cpu_percentage(self.spin_secs), [None] * 2)
         self.next(self.cpu_join)
 
     @resources(cpu=1)
@@ -99,7 +91,7 @@ class MonitorBench(FlowSpec):
         """
         One core, 50% utilized
         """
-        spin_cpu(self.spin_secs, half_load=True)
+        spin_cpu_percentage(self.spin_secs, percentage=50)
         self.next(self.cpu_join)
 
     @resources(cpu=2)
@@ -108,7 +100,7 @@ class MonitorBench(FlowSpec):
         """
         Two cores, each 50% utilized
         """
-        parallel_map(lambda _: spin_cpu(self.spin_secs, half_load=True), [None] * 2)
+        parallel_map(lambda _: spin_cpu_percentage(self.spin_secs, percentage=50), [None] * 2)
         self.next(self.cpu_join)
 
     @resources(cpu=8)
@@ -117,7 +109,7 @@ class MonitorBench(FlowSpec):
         """
         Eight cores, each 100% utilized
         """
-        parallel_map(lambda _: spin_cpu(self.spin_secs), [None] * 8)
+        parallel_map(lambda _: spin_cpu_percentage(self.spin_secs), [None] * 8)
         self.next(self.cpu_join)
 
     @resources(cpu=4)
@@ -126,7 +118,7 @@ class MonitorBench(FlowSpec):
         """
         Eight cores, each 100% utilized, but only 4 cores requested
         """
-        parallel_map(lambda _: spin_cpu(self.spin_secs), [None] * 8)
+        parallel_map(lambda _: spin_cpu_percentage(self.spin_secs), [None] * 8)
         self.next(self.cpu_join)
 
     @step
@@ -135,7 +127,7 @@ class MonitorBench(FlowSpec):
         Unspecified CPU resources.  Expected to be Metaflow default.
         Also allocates the Metaflow default amount of memory for this step.
         """
-        spin_cpu(self.spin_secs, half_load=False)
+        spin_cpu_percentage(self.spin_secs)
         self.next(self.cpu_join)
 
     @resources(cpu=0.5)
@@ -144,7 +136,7 @@ class MonitorBench(FlowSpec):
         """
         Fractional CPU resources requested.  Expected to be Metaflow default
         """
-        spin_cpu(self.spin_secs, half_load=True)
+        spin_cpu_percentage(self.spin_secs, percentage=50)
         self.next(self.cpu_join)
 
     @resources(cpu=1)
@@ -327,7 +319,7 @@ class MonitorBench(FlowSpec):
             num_gigs = 8
             with NamedTemporaryFile() as tmp:
                 _make_file(tmp.name, num_gigs * 1000)
-            spin_cpu(self.spin_secs / 10)
+            spin_cpu_percentage(self.spin_secs / 10)
         self.next(self.io_join)
 
     @step

--- a/monitorbench.py
+++ b/monitorbench.py
@@ -119,7 +119,8 @@ class MonitorBench(FlowSpec):
     @step
     def cpu_unspecified(self):
         """
-        Unspecified CPU resources.  Expected to be Metaflow default
+        Unspecified CPU resources.  Expected to be Metaflow default.
+        Also allocates the Metaflow default amount of memory for this step.
         """
         spin_cpu(self.spin_secs, half_load=False)
         self.next(self.cpu_join)
@@ -305,8 +306,6 @@ class MonitorBench(FlowSpec):
                 _make_file(tmp.name, num_gigs * 1000)
             spin_cpu(self.spin_secs / 10)
         self.next(self.io_join)
-
-
 
     @step
     def io_join(self, inputs):


### PR DESCRIPTION
[Sample test](https://ui.mozart.obp.outerbounds.com/dashboard/runs/p/default/MonitorBench/5568/cpu_staircase/242178?group=true&order=startTime&direction=asc)